### PR TITLE
Define STRICT to be compatible with Windows 10 SDK

### DIFF
--- a/os.hpp
+++ b/os.hpp
@@ -22,7 +22,10 @@
 
 #ifdef _WIN_ALL
 
-#define STRICT
+#ifndef STRICT
+#define STRICT 1
+#endif
+
 #define UNICODE
 #undef WINVER
 #undef _WIN32_WINNT


### PR DESCRIPTION
Fixes issue https://github.com/aawc/unrar/issues/11