### PR TITLE
Fixes to allow building in -std=c++20 mode.

### DIFF
--- a/blake2s.hpp
+++ b/blake2s.hpp
@@ -5,11 +5,8 @@
 #define BLAKE2_DIGEST_SIZE 32
 #define BLAKE2_THREADS_NUMBER 8
 
-enum blake2s_constant
-{
-  BLAKE2S_BLOCKBYTES = 64,
-  BLAKE2S_OUTBYTES   = 32
-};
+constexpr size_t BLAKE2S_BLOCKBYTES = 64;
+constexpr size_t BLAKE2S_OUTBYTES = 32;
 
 
 // Alignment to 64 improves performance of both SSE and non-SSE versions.
@@ -20,10 +17,10 @@ enum blake2s_constant
 // 'new' operator.
 struct blake2s_state
 {
-  enum { BLAKE_ALIGNMENT = 64 };
+  static constexpr size_t BLAKE_ALIGNMENT = 64;
 
   // buffer and uint32 h[8], t[2], f[2];
-  enum { BLAKE_DATA_SIZE = 48 + 2 * BLAKE2S_BLOCKBYTES };
+  static constexpr size_t BLAKE_DATA_SIZE = 48 + 2 * BLAKE2S_BLOCKBYTES;
 
   byte ubuf[BLAKE_DATA_SIZE + BLAKE_ALIGNMENT];
 

--- a/hash.cpp
+++ b/hash.cpp
@@ -26,7 +26,7 @@ void HashValue::Init(HASH_TYPE Type)
 }
 
 
-bool HashValue::operator == (const HashValue &cmp)
+bool HashValue::operator == (const HashValue &cmp) const
 {
   if (Type==HASH_NONE || cmp.Type==HASH_NONE)
     return true;

--- a/hash.hpp
+++ b/hash.hpp
@@ -6,8 +6,7 @@ enum HASH_TYPE {HASH_NONE,HASH_RAR14,HASH_CRC32,HASH_BLAKE2};
 struct HashValue
 {
   void Init(HASH_TYPE Type);
-  bool operator == (const HashValue &cmp);
-  bool operator != (const HashValue &cmp) {return !(*this==cmp);}
+  bool operator == (const HashValue &cmp) const;
 
   HASH_TYPE Type;
   union


### PR DESCRIPTION
* Various kinds of math involving enums are deprecated, so replace with
  constexprs where necessary.
* Types on both sides of "==" must match.

Bug: chromium:1284275