### PR TITLE
v7.12.0: Extracted from https://www.rarlab.com/rar/unrarsrc-7.1.8.tar.gz

### DIFF
--- a/dll.rc
+++ b/dll.rc
@@ -2,8 +2,8 @@
 #include <commctrl.h>
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 7, 12, 1, 1624
-PRODUCTVERSION 7, 12, 1, 1624
+FILEVERSION 7, 12, 100, 1637
+PRODUCTVERSION 7, 12, 100, 1637
 FILEOS VOS__WINDOWS32
 FILETYPE VFT_APP
 {
@@ -14,8 +14,8 @@ FILETYPE VFT_APP
       VALUE "CompanyName", "Alexander Roshal\0"
       VALUE "ProductName", "RAR decompression library\0"
       VALUE "FileDescription", "RAR decompression library\0"
-      VALUE "FileVersion", "7.12.1\0"
-      VALUE "ProductVersion", "7.12.1\0"
+      VALUE "FileVersion", "7.12.0\0"
+      VALUE "ProductVersion", "7.12.0\0"
       VALUE "LegalCopyright", "Copyright © Alexander Roshal 1993-2025\0"
       VALUE "OriginalFilename", "Unrar.dll\0"
     }

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #define RARVER_MAJOR     7
 #define RARVER_MINOR    12
-#define RARVER_BETA      1
-#define RARVER_DAY      10
+#define RARVER_BETA      0
+#define RARVER_DAY      23
 #define RARVER_MONTH     6
 #define RARVER_YEAR   2025


### PR DESCRIPTION
[sic] version number: v7.12.0 is a newer release than v7.12.1.