### PR TITLE
Roll unrar to https://www.rarlab.com/rar/unrarsrc-7.1.10.tar.gz

### DIFF
--- a/dll.cpp
+++ b/dll.cpp
@@ -331,7 +331,7 @@ int PASCAL RARReadHeaderEx(HANDLE hArcData,struct RARHeaderDataEx *D)
   {
     return Data->Cmd.DllError!=0 ? Data->Cmd.DllError : RarErrorToDll(ErrCode);
   }
-  return ERAR_SUCCESS;
+  return Data->Cmd.DllError!=0 ? Data->Cmd.DllError : RarErrorToDll(ErrHandler.GetErrorCode());
 }
 
 
@@ -428,7 +428,7 @@ int PASCAL ProcessFile(HANDLE hArcData,int Operation,char *DestPath,char *DestNa
   {
     return Data->Cmd.DllError!=0 ? Data->Cmd.DllError : RarErrorToDll(ErrCode);
   }
-  return Data->Cmd.DllError;
+  return Data->Cmd.DllError!=0 ? Data->Cmd.DllError : RarErrorToDll(ErrHandler.GetErrorCode());
 }
 
 

--- a/dll.rc
+++ b/dll.rc
@@ -2,8 +2,8 @@
 #include <commctrl.h>
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 7, 12, 100, 1637
-PRODUCTVERSION 7, 12, 100, 1637
+FILEVERSION 7, 13, 1, 1668
+PRODUCTVERSION 7, 13, 1, 1668
 FILEOS VOS__WINDOWS32
 FILETYPE VFT_APP
 {
@@ -14,8 +14,8 @@ FILETYPE VFT_APP
       VALUE "CompanyName", "Alexander Roshal\0"
       VALUE "ProductName", "RAR decompression library\0"
       VALUE "FileDescription", "RAR decompression library\0"
-      VALUE "FileVersion", "7.12.0\0"
-      VALUE "ProductVersion", "7.12.0\0"
+      VALUE "FileVersion", "7.13.1\0"
+      VALUE "ProductVersion", "7.13.1\0"
       VALUE "LegalCopyright", "Copyright © Alexander Roshal 1993-2025\0"
       VALUE "OriginalFilename", "Unrar.dll\0"
     }

--- a/dll.rc
+++ b/dll.rc
@@ -2,8 +2,8 @@
 #include <commctrl.h>
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION 7, 13, 1, 1668
-PRODUCTVERSION 7, 13, 1, 1668
+FILEVERSION 7, 13, 100, 1672
+PRODUCTVERSION 7, 13, 100, 1672
 FILEOS VOS__WINDOWS32
 FILETYPE VFT_APP
 {
@@ -14,8 +14,8 @@ FILETYPE VFT_APP
       VALUE "CompanyName", "Alexander Roshal\0"
       VALUE "ProductName", "RAR decompression library\0"
       VALUE "FileDescription", "RAR decompression library\0"
-      VALUE "FileVersion", "7.13.1\0"
-      VALUE "ProductVersion", "7.13.1\0"
+      VALUE "FileVersion", "7.13.0\0"
+      VALUE "ProductVersion", "7.13.0\0"
       VALUE "LegalCopyright", "Copyright © Alexander Roshal 1993-2025\0"
       VALUE "OriginalFilename", "Unrar.dll\0"
     }

--- a/os.hpp
+++ b/os.hpp
@@ -137,6 +137,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
+#include <stddef.h> // Needed for ptrdiff_t in some UnRAR source builds.
 #include <string.h>
 #include <ctype.h>
 #include <fcntl.h>

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #define RARVER_MAJOR     7
-#define RARVER_MINOR    12
-#define RARVER_BETA      0
-#define RARVER_DAY      23
-#define RARVER_MONTH     6
+#define RARVER_MINOR    13
+#define RARVER_BETA      1
+#define RARVER_DAY      24
+#define RARVER_MONTH     7
 #define RARVER_YEAR   2025

--- a/version.hpp
+++ b/version.hpp
@@ -1,6 +1,6 @@
 #define RARVER_MAJOR     7
 #define RARVER_MINOR    13
-#define RARVER_BETA      1
-#define RARVER_DAY      24
+#define RARVER_BETA      0
+#define RARVER_DAY      28
 #define RARVER_MONTH     7
 #define RARVER_YEAR   2025

--- a/win32stm.cpp
+++ b/win32stm.cpp
@@ -52,7 +52,7 @@ void ExtractStreams20(Archive &Arc,const std::wstring &FileName)
   std::wstring StreamName;
   CharToWide(Arc.StreamHead.StreamName,StreamName);
 
-  if (StreamName[0]!=':')
+  if (StreamName[0]!=':' || StreamName.find_first_of(L"\\/")!=std::wstring::npos)
   {
     uiMsg(UIERROR_STREAMBROKEN,Arc.FileName,FileName);
     ErrHandler.SetErrorCode(RARX_CRC);
@@ -128,7 +128,8 @@ void ExtractStreams20(Archive &Arc,const std::wstring &FileName)
 void ExtractStreams(Archive &Arc,const std::wstring &FileName,bool TestMode)
 {
   std::wstring StreamName=GetStreamNameNTFS(Arc);
-  if (StreamName[0]!=':')
+
+  if (StreamName[0]!=':' || StreamName.find_first_of(L"\\/")!=std::wstring::npos)
   {
     uiMsg(UIERROR_STREAMBROKEN,Arc.FileName,FileName);
     ErrHandler.SetErrorCode(RARX_CRC);


### PR DESCRIPTION
The first commit goes to https://www.rarlab.com/rar/unrarsrc-7.1.9.tar.gz, and the second to https://www.rarlab.com/rar/unrarsrc-7.1.10.tar.gz. The version numbers in the commit descriptions is the one from version.hpp in both releases. The most recent release is indeed at v7.13.0.